### PR TITLE
Use bitflags 0.1.0 from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,7 @@ name = "termios"
 version = "1.1.2"
 authors = ["Nathan Zadoks <nathan@nathan7.eu>"]
 build = "make"
+
+[dependencies]
+
+bitflags = "0.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![feature(globs)]
 #![feature(unsafe_destructor)]
 extern crate libc;
+#[macro_use]
+extern crate bitflags;
 
 use std::os::unix::prelude::*;
 use std::io::{IoResult, IoError};


### PR DESCRIPTION
bitflags has moved out from the main rust distribution.